### PR TITLE
Add new bindings with safe wrappers

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_char, c_double, c_int};
+use std::os::raw::{c_char, c_double, c_int, c_uint};
 use cairo_sys;
 use glib_sys;
 
@@ -23,6 +23,10 @@ extern "C" {
         document: *mut PopplerDocument,
         index: c_int,
     ) -> *mut PopplerPage;
+
+    pub fn poppler_document_get_metadata(document: *mut PopplerDocument) -> *mut c_char;
+    pub fn poppler_document_get_pdf_version_string (document: *mut PopplerDocument) -> *mut c_char;
+    pub fn poppler_document_get_permissions(document: *mut PopplerDocument) -> c_uint;
 
     pub fn poppler_page_get_size(
         page: *mut PopplerPage,


### PR DESCRIPTION
Add bindings for
        poppler_document_get_metadata
        poppler_document_get_pdf_version_string
        poppler_document_get_permissions

The safe wrappers have the following signatures:

impl PopplerDocument {
        pub fn get_metadata(&self) -> Option<String>
        pub fn get_pdf_version_string(&self) -> Option<String>
        pub fn get_permissions(&self) ->u8
}

test2 is extended with calls to these functions and some assertions

mirrored from **https://git.uni-paderborn.de/asta/poppler-rs**