### PR TITLE
Removed mutability requirement

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -19,7 +19,7 @@ extern "C" {
         error: *mut *mut glib_sys::GError,
     ) -> *mut PopplerDocument;
     pub fn poppler_document_new_from_data(
-        data: *const c_char,
+        data: *mut c_char,
         length: c_int,
         password: *const c_char,
         error: *mut *mut glib_sys::GError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl PopplerDocument {
         Ok(PopplerDocument(doc))
     }
     pub fn new_from_data(
-        data: &[u8],
+        data: &mut [u8],
         password: &str,
     ) -> Result<PopplerDocument, glib::error::Error> {
         if data.len() == 0 {
@@ -58,7 +58,7 @@ impl PopplerDocument {
 
         let doc = util::call_with_gerror(|err_ptr| unsafe {
             ffi::poppler_document_new_from_data(
-                data.as_ptr() as *const c_char,
+                data.as_mut_ptr() as *mut c_char,
                 data.len() as c_int,
                 pw.as_ptr(),
                 err_ptr,
@@ -240,7 +240,7 @@ mod tests {
         let mut file = File::open(path).unwrap();
         let mut data: Vec<u8> = Vec::new();
         file.read_to_end(&mut data).unwrap();
-        let doc: PopplerDocument = PopplerDocument::new_from_data(&data[..], "upw").unwrap();
+        let doc: PopplerDocument = PopplerDocument::new_from_data(&mut data[..], "upw").unwrap();
         let num_pages = doc.get_n_pages();
         let title = doc.get_title().unwrap();
         let metadata = doc.get_metadata();
@@ -265,8 +265,8 @@ mod tests {
 
     #[test]
     fn test3() {
-        let data = vec![];
+        let mut data = vec![];
 
-        assert!(PopplerDocument::new_from_data(&data[..], "upw").is_err());
+        assert!(PopplerDocument::new_from_data(&mut data[..], "upw").is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,12 +131,14 @@ impl PopplerPage {
         (width, height)
     }
 
-    pub fn render(&self, ctx: &mut cairo::Context) {
-        unsafe { ffi::poppler_page_render(self.0, ctx.to_raw_none()) }
+    pub fn render(&self, ctx: &cairo::Context) {
+        let ctx_raw = ctx.to_raw_none();
+        unsafe { ffi::poppler_page_render(self.0, ctx_raw) }
     }
 
-    pub fn render_for_printing(&self, ctx: &mut cairo::Context) {
-        unsafe { ffi::poppler_page_render_for_printing(self.0, ctx.to_raw_none()) }
+    pub fn render_for_printing(&self, ctx: &cairo::Context) {
+        let ctx_raw = ctx.to_raw_none();
+        unsafe { ffi::poppler_page_render_for_printing(self.0, ctx_raw) }
     }
 
     pub fn get_text(&self) -> Option<&str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ mod tests {
         println!("Document has {} page(s)", num_pages);
 
         let mut surface = pdf::File::new(420.0, 595.0, "output.pdf");
-        let mut ctx = Context::new(&mut surface);
+        let ctx = Context::new(&mut surface);
 
         // FIXME: move iterator to poppler
         for page_num in 0..num_pages {
@@ -184,7 +184,7 @@ mod tests {
             surface.set_size(w, h);
 
             ctx.save();
-            page.render(&mut ctx);
+            page.render(&ctx);
 
             println!("Text: {:?}", page.get_text().unwrap_or(""));
 
@@ -224,10 +224,10 @@ mod tests {
         assert_eq!(title, "This is a test PDF file");
 
         let mut surface = ImageSurface::create(Format::ARgb32, w as i32, h as i32).unwrap();
-        let mut ctx = Context::new(&mut surface);
+        let ctx = Context::new(&mut surface);
 
         ctx.save();
-        page.render(&mut ctx);
+        page.render(&ctx);
         ctx.restore();
         ctx.show_page();
 


### PR DESCRIPTION
The `cairo::Context::to_raw_none()` method does not require a `&mut self`, but `&self` only.  
With this change the value given by `gtk::WidgetExt::connect_draw` (as in https://github.com/gtk-rs/examples/blob/master/src/bin/cairotest.rs#L104), which is an `&Context`, should work with this poppler render binding (I did a working local test).