### PR TITLE
Updated Dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,5 @@ repository = "https://github.com/DMSrs/poppler-rs"
 edition = "2018"
 
 [dependencies]
-cairo-rs = { version= "0.6.0", features = ["png", "pdf"]}
-cairo-sys-rs = "0.8.0"
-glib = "0.7.1"
-glib-sys = "0.8.0"
-gobject-sys = "0.8.0"
+cairo-rs = { version = "0.14", features = ["png", "pdf"] }
+glib = "0.14"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,5 +1,3 @@
-use cairo_sys;
-use glib_sys;
 use std::os::raw::{c_char, c_double, c_int, c_uint};
 
 // FIXME: is this the correct way to get opaque types?
@@ -16,13 +14,13 @@ extern "C" {
     pub fn poppler_document_new_from_file(
         uri: *const c_char,
         password: *const c_char,
-        error: *mut *mut glib_sys::GError,
+        error: *mut *mut glib::ffi::GError,
     ) -> *mut PopplerDocument;
     pub fn poppler_document_new_from_data(
         data: *mut c_char,
         length: c_int,
         password: *const c_char,
-        error: *mut *mut glib_sys::GError,
+        error: *mut *mut glib::ffi::GError,
     ) -> *mut PopplerDocument;
     pub fn poppler_document_get_n_pages(document: *mut PopplerDocument) -> c_int;
     pub fn poppler_document_get_page(
@@ -40,8 +38,8 @@ extern "C" {
         width: *mut c_double,
         height: *mut c_double,
     );
-    pub fn poppler_page_render(page: *mut PopplerPage, cairo: *mut cairo_sys::cairo_t);
-    pub fn poppler_page_render_for_printing(page: *mut PopplerPage, cairo: *mut cairo_sys::cairo_t);
+    pub fn poppler_page_render(page: *mut PopplerPage, cairo: *mut cairo::ffi::cairo_t);
+    pub fn poppler_page_render_for_printing(page: *mut PopplerPage, cairo: *mut cairo::ffi::cairo_t);
 
     pub fn poppler_page_get_text(page: *mut PopplerPage) -> *mut c_char;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,20 +1,20 @@
-use glib;
-use glib_sys::GError;
 use std::ffi::{CString, OsString};
 use std::{fs, path, ptr};
 
+use glib::translate::FromGlibPtrFull;
+
 pub fn call_with_gerror<T, F>(f: F) -> Result<*mut T, glib::error::Error>
 where
-    F: FnOnce(*mut *mut GError) -> *mut T,
+    F: FnOnce(*mut *mut glib::ffi::GError) -> *mut T,
 {
     // initialize error to a null-pointer
     let mut err = ptr::null_mut();
 
     // call the c-library function
-    let return_value = f(&mut err as *mut *mut GError);
+    let return_value = f(&mut err as *mut *mut glib::ffi::GError);
 
     if return_value.is_null() {
-        Err(glib::error::Error::wrap(err))
+        unsafe { Err(glib::error::Error::from_glib_full(err)) }
     } else {
         Ok(return_value)
     }


### PR DESCRIPTION
Just updated `cairo-rs` and `glib` to 0.14 - and removed the `*-sys` dependencies which shouldn't be required.

Does require one `unsafe` line which is not ideal but seems to be unavoidable - would be more than happy for it to be fixed.