### PR TITLE
Re-export cairo for rendering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_double, c_int};
 use std::path;
 
+/// Re-exports `cairo` to provide types required for rendering.
+#[cfg(feature = "render")]
+pub use cairo;
+
 mod ffi;
 mod util;
 


### PR DESCRIPTION
The current version relies on cairo types to be passed to the public interface of the `render` function. Version drifts make it complicated to align `poppler` and `cairo-rs`, so I added a public re-export of cairo.